### PR TITLE
Install vonage-status-panel plugin.

### DIFF
--- a/helm/grafana-values.yml
+++ b/helm/grafana-values.yml
@@ -1,6 +1,7 @@
 replicas: 2
 plugins:
   - grafana-azure-monitor-datasource
+  - vonage-status-panel
 admin:
   existingSecret: grafana-admin-user
 grafana.ini:


### PR DESCRIPTION
This PR is to install the [vonage-status-panel](https://grafana.com/plugins/vonage-status-panel) plugin in Grafana for testing in the new services dashboards.