### PR TITLE
Moved basicAuth and basicAuthUser out of jsonData

### DIFF
--- a/helm/grafana-values.yml
+++ b/helm/grafana-values.yml
@@ -65,13 +65,12 @@ datasources:
         access: proxy
         database: "[das-logstash*]YYYY.MM.DD"
         url: __ElasticSearchLoggingUrl__
+        basicAuth: true
+        basicAuthUser: __ElasticsearchLoggingServiceAccountUser__
         jsonData:
           interval: Daily
           timeField: "@timestamp"
           esVersion: 70
-          basicAuth: true
-          basicAuthUser: __ElasticsearchLoggingServiceAccountUser__
-          withCredentials: true
         secureJsonData:
           basicAuthPassword: __ElasticsearchLoggingServiceAccountPassword__
 
@@ -126,12 +125,11 @@ datasources:
         access: proxy
         database: "[das-logstash*]YYYY.MM.DD"
         url: __ElasticSearchLoggingUrl__
+        basicAuth: true
+        basicAuthUser: __ElasticsearchLoggingServiceAccountUser__
         jsonData:
           interval: Daily
           timeField: "@timestamp"
           esVersion: 70
-          basicAuth: true
-          basicAuthUser: __ElasticsearchLoggingServiceAccountUser__
-          withCredentials: true
         secureJsonData:
           basicAuthPassword: __ElasticsearchLoggingServiceAccountPassword__


### PR DESCRIPTION
As per the Grafana documentation https://grafana.com/docs/administration/provisioning/#datasources I have moved `basicAuth` and `basicAuthUser` out of the `jsonData` section. 