### PR TITLE
Downgrade to 6.5.2 to Try and Fix the App Gateway FE/BE Graph Images

### DIFF
--- a/helm/grafana-values.yml
+++ b/helm/grafana-values.yml
@@ -1,6 +1,6 @@
 replicas: 2
 image:
-  tag: 6.5.3
+  tag: 6.5.2
 nodeSelector:
   agentpool: mgmt
 resources:


### PR DESCRIPTION
In the das-alerts slack channel, the App Gateway FE/BE health alerts no longer show the graphs from Grafana in the screenshot attachment. It now shows the following error: 

```Prometheus Plugin Failed. Error: Loading chunk 44 failed. (missing:http://localhost:3000/public/build/prometheusPlugin.2ffa3667c2c8a7a8351f.js)```

More information here: https://github.com/grafana/grafana/issues/21733

This PR downgrades Grafana from 6.5.3 to 6.5.2.

