### PR TITLE
Remove datasources as no longer required

### DIFF
--- a/helm.yml
+++ b/helm.yml
@@ -12,15 +12,6 @@ plugins:
   - flant-statusmap-panel
   - simpod-json-datasource
   - grafana-piechart-panel
-datasources:
-  datasources.yaml:
-    apiVersion: 1
-    datasources:
-    - name: "Elasticsearch - Logging"
-      type: elasticsearch
-      orgId: 3
-      readOnly: false
-      editable: true
 admin:
   existingSecret: grafana-admin-user
   userKey: admin-user

--- a/manifest/ingress.yml
+++ b/manifest/ingress.yml
@@ -8,6 +8,7 @@ metadata:
     kubernetes.io/ingress.class: azure/application-gateway
     appgw.ingress.kubernetes.io/appgw-ssl-certificate: {{TlsSecretName}}
     appgw.ingress.kubernetes.io/ssl-redirect: "true"
+    appgw.ingress.kubernetes.io/health-probe-path: "/api/health"
 spec:
   rules:
   - host: {{IngressHost}}


### PR DESCRIPTION
Removing datasources section from the helm.yml as it was only required to make the broken Elasticsearch data source editable. A replacement has been made manually. This will then clean up the changes as otherwise an additional blank Elasticsearch datasource will be created everytime the pipeline is run. 