### PR TITLE
deploy-grafana.yml: Changed to deployment agent

### DIFF
--- a/pipeline-templates/job/deploy-grafana.yml
+++ b/pipeline-templates/job/deploy-grafana.yml
@@ -20,9 +20,7 @@ jobs:
 - deployment: DeployTo_${{ parameters.Environment }}
   environment: ${{ parameters.Environment }}
   pool:
-    name: DAS - Continuous Integration Agents
-    ## Linux agent required to ensure the 'kubectl cp' in Copy-FileToContainer.ps1 functions as expected
-    demands: Agent.OS -equals Linux
+    name: DAS - Continuous Deployment Agents
   variables:
   - name: KubernetesNamespace
     value: monitoring


### PR DESCRIPTION
Requirement of Linux agent is no longer relevant, there is no Copy-FileToContainer.ps1 file with `kubectl cp` commands referenced in the now-deleted comment of pipeline-templates/job/deploy-grafana.yml