### PR TITLE
Updated Grafana from 8.5.14 to 9.3.6

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -21,11 +21,11 @@ trigger:
 variables:
 - group: Release Management Resources
 - name: HelmClientVersion
-  value: 3.6.3
+  value: 3.11.1
 - name: HelmChartVersion
-  value: 6.40.4
+  value: 6.50.7
 - name: KubectlVersion
-  value: 1.23.8
+  value: 1.25.5
 
 stages:
 - stage: Deploy_PREPROD

--- a/helm.yml
+++ b/helm.yml
@@ -1,4 +1,4 @@
-#Reference chart version 6.14.1 values.yml at https://github.com/grafana/helm-charts/blob/bea1de88b4e991251e6c0cce27a149eceb09d9bc/charts/grafana/values.yaml
+#Reference chart version 6.50.7 values.yml at https://github.com/grafana/helm-charts/blob/bf834bfa74e4f00d41e6de8acec258eefa2b35f9/charts/grafana/values.yaml
 replicas: 2
 image:
   repository: grafana/grafana
@@ -18,6 +18,8 @@ admin:
   existingSecret: grafana-admin-user
   userKey: admin-user
   passwordKey: admin-password
+rbac:
+  pspEnabled: false
 grafana.ini:
   users:
     auto_assign_org: true

--- a/helm.yml
+++ b/helm.yml
@@ -2,7 +2,7 @@
 replicas: 2
 image:
   repository: grafana/grafana
-  tag: 8.5.14
+  tag: 9.3.6
 nodeSelector:
   agentpool: tools01
 resources:


### PR DESCRIPTION
- Updated Grafana from 8.5.14 to 9.3.6 https://grafana.com/docs/grafana/v9.3/
- Updated HelmChartVersion from 6.40.4 to 6.50.7 https://github.com/grafana/helm-charts/releases/tag/grafana-6.50.7
- Updated HelmClientVersion from 3.6.3 to 3.11.1
- Updated KubectlVersion from 1.23.8 to 1.25.5
- Set rbac.pspEnabled to false as Pod Security Policies are removed from Kubernetes in v1.25 https://kubernetes.io/docs/concepts/security/pod-security-policy/